### PR TITLE
Add more prompts (time zone, psql user name, psql db name, SElinux status to permissive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,3 @@ With curl:
 ```
 curl -L https://raw.github.com/Palmc/ZabbixScript/master/installZabbix.bash > installZabbix.bash && bash installZabbix.bash
 ```
-**NOTE**
-
-The default timezone in **/etc/httpd/conf.d/zabbix.conf** or **/etc/zabbix/apache.conf** is Europe/Madrid, you must change the timezone to adjust it to your location, the list of supported timezones is here: http://php.net/manual/en/timezones.php

--- a/installZabbix.bash
+++ b/installZabbix.bash
@@ -3,49 +3,66 @@
 set -e
 printf "\033c"
 
-setPassword(){
-	#Set password of PostgreSQL´s zabbix user
-	echo "Enter the password that the PostgreSQL´s zabbix user will have"
+setTimeZone(){
+	# Set time zone
+	read -p "Enter the time zone: " time_zone
+}
+
+setPsqlUser(){
+	# Set PostgreSQL user name
+	read -p "Enter the PostgreSQL user name: " psql_user
+}
+
+setPsqlPassword(){
+	# Set password of PostgreSQL's $psql_user user
+	echo "Enter the password that the PostgreSQL's $psql_user user will have."
 	while true; do
-		echo -e "\n"
-		read -s -p "Password: " db_pass
-		echo -e "\n"
-		read -s -p "Type password again: " db_pass2
-	 	[ "$db_pass" = "$db_pass2" ] && break
+		read -s -p "Password: " psql_pass
+		read -s -p "Type password again: " psql_pass2
+		[ "$psql_pass" = "$psql_pass2" ] && break
 		echo -e "\nError, please try again"
 	done
 	echo -e "\n\e[92mSucess!!\e[0m"
 }
 
+setPsqlDbName(){
+	# Set PostgreSQL database name
+	read -p "Enter the PostgreSQL database name: " psql_db_name
+}
+
 installCentos(){
-	#Detect SElinux status
+	# Detect SElinux status
 	SELINUXSTATUS=$(getenforce)
 	if [ "$SELINUXSTATUS" == "Enforcing" ]; then
 		echo "SElinux is set as Enforcing, disable it or adjust your configuration"
-		read -n 1 -s -r -p "Press any key to continue"
+		read -p "Would you like to change it to permissive? " ans
+		case "$ans" in
+			[yY]|[yY][eE][sS]) setenforce 0 && echo -e "\n\e[92mSucess!!\e[0m" ;;
+			*) read -n 1 -s -r -p "Press any key to continue" ;;
+		esac
 		echo -e "\n"
-	fi;
+	fi
 	
-	#Adding repositories
-	yum install yum-utils epel-release -y
+	# Adding repositories
+	yum -y install yum-utils epel-release
 	rpm -Uvh http://rpms.remirepo.net/enterprise/remi-release-7.rpm
 	rpm -Uvh https://repo.zabbix.com/zabbix/4.0/rhel/7/x86_64/zabbix-release-4.0-1.el7.noarch.rpm
 	rpm -Uvh https://yum.postgresql.org/10/redhat/rhel-7-x86_64/pgdg-centos10-10-2.noarch.rpm
 	yum-config-manager --enable remi-php72
 	
-	#Installing Zabbix components and PostgreSQL
+	# Installing Zabbix components and PostgreSQL
 	
-	yum install zabbix-server-pgsql zabbix-web-pgsql zabbix-agent postgresql10-contrib postgresql10-server -y
+	yum -y install zabbix-server-pgsql zabbix-web-pgsql zabbix-agent postgresql10-contrib postgresql10-server
 
 	/usr/pgsql-10/bin/postgresql-10-setup initdb
 	systemctl start postgresql-10.service; systemctl enable postgresql-10.service
 
-	cd /var/lib/
+	cd /var/lib
 
 	sudo -u postgres psql <<EOF
-		create user "zabbix" with password '$db_pass2';
-		create database zabbix with owner zabbix;
-		GRANT ALL PRIVILEGES ON DATABASE zabbix TO zabbix;
+		create user "$psql_user" with password '$psql_pass';
+		create database "$psql_db_name" with owner "$psql_user";
+		GRANT ALL PRIVILEGES ON DATABASE "$psql_db_name" TO "$psql_user";
 EOF
 	sed -i "s|local   all             all                                     peer|local   all             all                                     trust|g" /var/lib/pgsql/10/data/pg_hba.conf
 	sed -i "s|host    all             all             127.0.0.1/32            ident|host    all             all             127.0.0.1/32            md5|g" /var/lib/pgsql/10/data/pg_hba.conf
@@ -53,48 +70,53 @@ EOF
 
 	systemctl restart postgresql-10.service
 
-	zcat /usr/share/doc/zabbix-server-pgsql*/create.sql.gz | sudo -u zabbix psql zabbix 
+	zcat /usr/share/doc/zabbix-server-pgsql*/create.sql.gz | sudo -u "$psql_user" psql "$psql_db_name" 
 
-	sed -i "s|# DBPassword=|DBPassword=$db_pass2|g" /etc/zabbix/zabbix_server.conf
+	sed -i "s|# DBPassword=|DBPassword=$psql_pass|g" /etc/zabbix/zabbix_server.conf
 	sed -i "s|    <IfModule mod_php5.c>|    <IfModule mod_php7.c>|g" /etc/httpd/conf.d/zabbix.conf
-	sed -i "s|        # php_value date.timezone Europe/Riga|        php_value date.timezone Europe/Madrid|g" /etc/httpd/conf.d/zabbix.conf
+	sed -i "s|        # php_value date.timezone Europe/Riga|        php_value date.timezone $time_zone|g" /etc/httpd/conf.d/zabbix.conf
 
-	systemctl restart zabbix-server zabbix-agent httpd; systemctl enable zabbix-server zabbix-agent httpd 
+	systemctl restart zabbix-server zabbix-agent httpd; systemctl enable zabbix-server zabbix-agent httpd
+
+	# I (tukusejssirs) had an error in http://$ip/zabbix/setup.php, when it checked the pre-requisities,
+	# particularly with "Assets cache directory permissions", which was read-only
+	# The following command fixes this error (I have no idea if it is needed in other distros, too)
+	chmod -R 777 /usr/share/zabbix/assets
 }
 
 installDebianBased() {
-	#Adding repositories
-	wget https://repo.zabbix.com/zabbix/4.0/$ID/pool/main/z/zabbix-release/zabbix-release_4.0-2+`lsb_release -cs`_all.deb
-	dpkg -i zabbix-release_4.0-2+`lsb_release -cs`_all.deb
+	# Adding repositories
+	wget https://repo.zabbix.com/zabbix/4.0/$ID/pool/main/z/zabbix-release/zabbix-release_4.0-2+$(lsb_release -cs)_all.deb
+	dpkg -i zabbix-release_4.0-2+$(lsb_release -cs)_all.deb
 	wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O- | apt-key add -
-	echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee /etc/apt/sources.list.d/postgresql.list
+	echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" | tee /etc/apt/sources.list.d/postgresql.list
 	apt update
 
 
-	#Installing Zabbix components and PostgreSQL
-	apt install -y zabbix-server-pgsql zabbix-frontend-php php-pgsql zabbix-agent postgresql-10 sudo
+	# Installing Zabbix components and PostgreSQL
+	apt install -y zabbix-server-pgsql zabbix-frontend-php php-pgsql zabbix-agent postgresql-10
 
 	cd /var/lib/postgresql/
 	systemctl start postgresql; systemctl enable postgresql
 	sudo -u postgres psql <<EOF
-		create user "zabbix" with password '$db_pass2';
-		create database zabbix with owner zabbix;
-		GRANT ALL PRIVILEGES ON DATABASE zabbix TO zabbix;
+		create user "$psql_user" with password '$psql_pass';
+		create database "$psql_db_name" with owner "$psql_user";
+		GRANT ALL PRIVILEGES ON DATABASE "$psql_db_name" TO "$psql_user";
 EOF
 
-	zcat /usr/share/doc/zabbix-server-pgsql/create.sql.gz | sudo -u zabbix psql zabbix
+	zcat /usr/share/doc/zabbix-server-pgsql/create.sql.gz | sudo -u "$psql_user" psql "$psql_db_name"
 
 
-	sed -i "s|# DBPassword=|DBPassword=$db_pass2|g" /etc/zabbix/zabbix_server.conf
-	sed -i "s|        # php_value date.timezone Europe/Riga|        php_value date.timezone Europe/Madrid|g" /etc/zabbix/apache.conf
+	sed -i "s|# DBPassword=|DBPassword=$psql_pass|g" /etc/zabbix/zabbix_server.conf
+	sed -i "s|        # php_value date.timezone Europe/Riga|        php_value date.timezone $time_zone|g" /etc/zabbix/apache.conf
 
 	systemctl restart zabbix-server zabbix-agent apache2; systemctl enable zabbix-server zabbix-agent apache2 
 }
 
 installRaspbian(){
 	#Adding repositories
-	wget https://repo.zabbix.com/zabbix/4.0/$ID/pool/main/z/zabbix-release/zabbix-release_4.0-2+`lsb_release -cs`_all.deb
-	dpkg -i zabbix-release_4.0-2+`lsb_release -cs`_all.deb
+	wget https://repo.zabbix.com/zabbix/4.0/$ID/pool/main/z/zabbix-release/zabbix-release_4.0-2+$(lsb_release -cs)_all.deb
+	dpkg -i zabbix-release_4.0-2+$(lsb_release -cs)_all.deb
 	apt update
 	
 	#Installing Zabbix components and PostgreSQL
@@ -102,36 +124,37 @@ installRaspbian(){
 	cd /var/lib/postgresql/
 	systemctl start postgresql; systemctl enable postgresql
 	sudo -u postgres psql <<EOF
-		create user "zabbix" with password '$db_pass2';
-		create database zabbix with owner zabbix;
-		GRANT ALL PRIVILEGES ON DATABASE zabbix TO zabbix;
+		create user "$psql_user" with password '$psql_pass';
+		create database "$psql_db_name" with owner "$psql_user";
+		GRANT ALL PRIVILEGES ON DATABASE "$psql_db_name" TO "$psql_user";
 EOF
 
-	zcat /usr/share/doc/zabbix-server-pgsql/create.sql.gz | sudo -u zabbix psql zabbix
+	zcat /usr/share/doc/zabbix-server-pgsql/create.sql.gz | sudo -u "$psql_user" psql "$psql_db_name"
 
-	sed -i "s|# DBPassword=|DBPassword=$db_pass2|g" /etc/zabbix/zabbix_server.conf
-	sed -i "s|        # php_value date.timezone Europe/Riga|        php_value date.timezone Europe/Madrid|g" /etc/zabbix/apache.conf
+	sed -i "s|# DBPassword=|DBPassword=$psql_pass|g" /etc/zabbix/zabbix_server.conf
+	sed -i "s|        # php_value date.timezone Europe/Riga|        php_value date.timezone $time_zone|g" /etc/zabbix/apache.conf
 
 	systemctl restart zabbix-server zabbix-agent apache2; systemctl enable zabbix-server zabbix-agent apache2 
 }
 
-#Detect distrib
+# Detect distribution
 source /etc/os-release
+setTimeZone
+setPsqlUser
+setPsqlPassword
+setPsqlDbName
 case $ID in
 	centos)
-		setPassword
 		installCentos
 		;;
 	debian|ubuntu)
-		setPassword
 		installDebianBased
 		;;
 	raspbian)
-		setPassword
 		installRaspbian
 		;;
 	*)
-		echo "Distribution not supported"
+		echo "Distribution $ID is currently not supported."
 		exit 1
 		;;
 esac
@@ -142,6 +165,6 @@ echo "############################################"
 echo " "
 ip=$(hostname -I|cut -f1 -d ' ')
 echo -e "Now you must continue here: \e[92mhttp://$ip/zabbix/setup.php\e[0m"
-echo -e "\nOn web interface:"
-echo -e "Default user: \e[33mAdmin\e[0m"
+echo -e "\nIn the web interface:"
+echo -e "Default user:     \e[33mAdmin\e[0m"
 echo -e "Default password: \e[33mzabbix\e[0m"


### PR DESCRIPTION
@Palmc, I have found your script very helpful, however, I missed some things from it. Here’s a PR that would add them. I have also thought about adding [dialog](http://linuxcommand.org/lc3_adv_dialog.php) to make it a bit more interactive (I still can add it if you wish), however, I did not think it is necessary.

If you don’t like anything, just tell me, I’ll change it. :)

Here’s the change log:

- Add a prompt for user time zone
- Add a prompt for PostgreSQL user name
- Add a prompt for PostgreSQL database name
- Add a prompt if the script should change the SElinux to permissive

- Fix the format of the comments
- Replace backticks with "dollar parentheses" ([reason](https://unix.stackexchange.com/a/126928))
- Removed the note on time zone from README.md